### PR TITLE
Update Submit issue link

### DIFF
--- a/api-docs/_deconst.json
+++ b/api-docs/_deconst.json
@@ -1,6 +1,6 @@
 {
   "contentIDBase": "https://github.com/rackerlabs/docs-cloud-monitoring/",
-  "githubUrl": "https://github.com/rackerlabs/docs-rackspace/",
+  "githubUrl": "https://github.com/rackerlabs/docs-cloud-monitoring/",
   "githubBranch": "master",
   "meta": {
     "preferGithubIssues": true


### PR DESCRIPTION
Per Shane Duan made Monitoring doc repo public so the
submit issue link can go directly to the Monitoring repo
instead of going to docs-rackspace