### PR TITLE
Fix header syntax in agent.filesystem_state

### DIFF
--- a/api-docs/tech-ref-info/check-types/agent-check-type-ref.rst
+++ b/api-docs/tech-ref-info/check-types/agent-check-type-ref.rst
@@ -216,18 +216,18 @@ Metrics
 .. _agent_filesystem_state:
 
 agent.filesystem_state
--------------------------
+----------------------
 
 The **agent.filesystem_state** check exposes filesystem metrics for
 read-write/read-only system mounts.
 
 Attributes
-~~~~~~~~~~~~
+^^^^^^^^^^
 
 No fields are present for this particular check type.
 
 Metrics
-~~~~~~~~~~~~
+^^^^^^^
 
 +-----------------+--------------------------------------------------+----------+
 | Metric          | Description                                      | Type     |


### PR DESCRIPTION
Attributes and Metrics section had wrong heading level which 
broke the TOC hierarchy for the Agent Check Types per 
comment in issue #5.
