### PR TITLE
Terminology corrections

### DIFF
--- a/api-docs/api-reference/account-operations.rst
+++ b/api-docs/api-reference/account-operations.rst
@@ -5,7 +5,7 @@ Account
 =======
 
 Use the following Account operations to manage user accounts including finding
-out about resource and rate limits and getting information on write operations,
+out about resource and rate limits and getting information about write operations,
 called audits.
 
 .. contents::

--- a/api-docs/api-reference/agents-operations.rst
+++ b/api-docs/api-reference/agents-operations.rst
@@ -5,7 +5,7 @@ Agents
 ======
 
 The optional Monitoring Agent resides on the host server being
-monitored. The agent allows you to gather on-host metrics
+monitored. You can use the agent to gather on-host metrics
 based on agent checks and push them to Rackspace Monitoring where
 you can analyze them, use them with the Rackspace Monitoring
 infrastructure, and archive them.
@@ -64,7 +64,7 @@ infrastructure:
   Agent updates are verified against a cryptographic digest which is signed
   by the agent root certificate authority. This signing certificate is
   separate from the endpoint TLS certificate and the signing is done on
-  a single machine, off-line. This means that the security of updates
+  a single computer, off-line. This means that the security of updates
   is separated from that of the endpoint.
 
 Agent IDs

--- a/api-docs/api-reference/entities-operations.rst
+++ b/api-docs/api-reference/entities-operations.rst
@@ -12,8 +12,8 @@ monitor each server in a cluster, you would create an entity for each
 of the servers. You would not create a single entity to represent the
 entire cluster.
 
-An entity can have multiple checks associated with it. This allows you
-to check multiple services on the same host by creating multiple
+An entity can have multiple checks associated with it. Multiple checks enable
+you to check multiple services on the same host by creating multiple
 checks on the same entity, instead of multiple entities each with a
 single check.
 

--- a/api-docs/api-reference/methods/get-audit-information.rst
+++ b/api-docs/api-reference/methods/get-audit-information.rst
@@ -10,7 +10,7 @@ Get audit information
 Returns audit information for the specified account.
 
 Rackspace Monitoring records every write operation in an audit.
-For more information on how audits are recorded, see
+For more information about how audits are recorded, see
 :ref:`Audits <audits>`.
 
 Audits are accessible as a

--- a/api-docs/api-reference/methods/get-data-points-by-metric-name.rst
+++ b/api-docs/api-reference/methods/get-data-points-by-metric-name.rst
@@ -18,7 +18,7 @@ This operation does not require a request body.
 This operation returns a response body that lists all data points
 between two points in time for ``metricName``. To control the data points
 returned in the response body, specify the required request URI
-parameters described below.
+parameters described in the following table.
 
 .. note::
    Rackspace Monitoring is currently limited to 1440 data points returned
@@ -46,7 +46,7 @@ The following table shows the possible response codes for this operation:
 +--------------------------+-------------------------+-------------------------+
 |405                       |Method Not Allowed       |The method specified in  |
 |                          |                         |the request is not       |
-|                          |                         |allowed for the          |
+|                          |                         |enabled for the          |
 |                          |                         |resource. A list of      |
 |                          |                         |valid methods for the    |
 |                          |                         |requested resource is    |

--- a/api-docs/api-reference/methods/get-information-about-host-users-agents.rst
+++ b/api-docs/api-reference/methods/get-information-about-host-users-agents.rst
@@ -7,7 +7,7 @@ Get information about host users
 
     GET /agents/{agentId}/host_info/who
 
-Get information on users who are logged into the host.
+Get information about users who are logged into the host.
 
 The following table shows the possible response codes for this operation:
 

--- a/api-docs/api-reference/methods/get-list-alarms-entity.rst
+++ b/api-docs/api-reference/methods/get-list-alarms-entity.rst
@@ -9,7 +9,7 @@ List alarms
 
 List the alarms on the specified ``entityId``. Use
 ``/alarms?id=alarmOneId & id=alarmTwoId`` to filter the results to only
-include information on the specified alarms.
+include information about the specified alarms.
 
 This operation can be paginated. For information, see
 :ref: `Paginated collections <paginated-collections>`.

--- a/api-docs/api-reference/methods/get-list-checks-for-an-entity.rst
+++ b/api-docs/api-reference/methods/get-list-checks-for-an-entity.rst
@@ -10,7 +10,7 @@ List checks for an entity
 Lists the checks associated with a given ``entityId``.
 
 Use ``/checks?id=checkOneId & id=checkTwoId`` to filter the
-results to only include information on the specified checks.
+results to only include information about the specified checks.
 
 This operation can be paginated. For information,
 see :ref:`Paginated collections <paginated-collections>`.

--- a/api-docs/api-reference/methods/get-list-metrics-by-check-id.rst
+++ b/api-docs/api-reference/methods/get-list-metrics-by-check-id.rst
@@ -61,7 +61,7 @@ The following table shows the possible response codes for this operation:
 +--------------------------+-------------------------+-------------------------+
 |405                       |Method Not Allowed       |The method specified in  |
 |                          |                         |the request is not       |
-|                          |                         |allowed for the          |
+|                          |                         |supported for the        |
 |                          |                         |resource. A list of      |
 |                          |                         |valid methods for the    |
 |                          |                         |requested resource is    |

--- a/api-docs/api-reference/methods/get-list-notification-plans.rst
+++ b/api-docs/api-reference/methods/get-list-notification-plans.rst
@@ -8,7 +8,7 @@ List notification plans
 
 Lists the notification plans for the Rackspace Cloud Monitoring account.
 Use ``/notification_plans?id=notification_planOneId & id=notification_planTwoId``
-to filter the results to only include information on the specified
+to filter the results to only include information about the specified
 notification plans.
 
 This operation can be paginated. For information,

--- a/api-docs/api-reference/methods/get-list-notifications.rst
+++ b/api-docs/api-reference/methods/get-list-notifications.rst
@@ -9,7 +9,7 @@ List notifications
 
 Lists the notifications for the account. Use
 ``/notifications?id=notificationOneId & id=notificationTwoId`` to filter
-the results to only include information on the specified notifications.
+the results to only include information about the specified notifications.
 
 This operation can be paginated. For information,
 see :ref:`Paginated collections <paginated-collections>`.

--- a/api-docs/api-reference/methods/get-list-suppressions.rst
+++ b/api-docs/api-reference/methods/get-list-suppressions.rst
@@ -9,7 +9,7 @@ List suppressions
 
 Lists the suppressions. Use
 ``/supressions?id=supressionOneId & id=supressionTwoId`` to filter the results
-to only include information on the specified suppressions.
+to only include information about the specified suppressions.
 
 This operation can be paginated. For information,
 see :ref: `Paginated collections <paginated-collections>`.

--- a/api-docs/api-reference/methods/post-test-a-check-with-debug.rst
+++ b/api-docs/api-reference/methods/post-test-a-check-with-debug.rst
@@ -12,7 +12,7 @@ information, if available.
 
 This operation causes Rackspace Cloud Monitoring to attempt to run
 the check on the specified monitoring zones and return the results.
-This allows you to test the check parameters in a single step
+This enables you to test the check parameters in a single step
 before the check is actually created in the system. This call also includes
 debug information. Currently debug information is only available for the
 remote.http check and includes the response body.

--- a/api-docs/api-reference/methods/post-test-a-check.rst
+++ b/api-docs/api-reference/methods/post-test-a-check.rst
@@ -9,7 +9,7 @@ Test a check
 
 This operation causes Rackspace Cloud Monitoring to attempt to
 run the check on the specified monitoring zones and return the results.
-This operation allows you to test the check parameters in a single
+This operation enables you to test the check parameters in a single
 step before the check is actually created in the system.
 
 .. note::

--- a/api-docs/api-reference/methods/post-test-a-notification.rst
+++ b/api-docs/api-reference/methods/post-test-a-notification.rst
@@ -7,9 +7,9 @@ Test a notification
 
     POST /test-notification
 
-This operation allows you to test a notification before creating it.
+This operation enables you to test a notification before creating it.
 The actual notification comes from the same server where the
-actual alert messages come from. This allow you to, among other things,
+actual alert messages come from. This enables you to, among other things,
 verify that your firewall is configured properly.
 
 The following table shows the possible response codes for this operation:

--- a/api-docs/api-reference/methods/post-test-an-existing-check.rst
+++ b/api-docs/api-reference/methods/post-test-an-existing-check.rst
@@ -11,7 +11,7 @@ Test an existing check inline.
 
 This operation causes Rackspace Cloud Monitoring to attempt to run a
 duplicate check on the specified monitoring zones and return the
-results. This allows you to test the check parameters.
+results. This enables you to test the check parameters.
 
 .. note::
    This operation does NOT cause the already-created check to

--- a/api-docs/api-reference/methods/post-test-an-existing-notification.rst
+++ b/api-docs/api-reference/methods/post-test-an-existing-notification.rst
@@ -7,7 +7,7 @@ Test an existing notification
 
     POST /notifications/{notificationId}/test
 
-This operation allows you to test an existing notification. The
+This operation enables you to test an existing notification. The
 notification comes from the same server that the alert messages
 come from. One use for this test is to verify that your firewall
 is configured properly.

--- a/api-docs/api-reference/suppressions-operations.rst
+++ b/api-docs/api-reference/suppressions-operations.rst
@@ -4,7 +4,7 @@
 Suppressions
 ============
 
-Suppressions allow you to suspend alarm notifications for a set period of time.
+Suppressions enable you to suspend alarm notifications for a set period of time.
 A single suppression can apply to any number of alarms. For example,
 you would use one suppression to suppress all alarm notifications during
 a scheduled maintenance period this week and another suppression

--- a/api-docs/api-reference/zones-operations.rst
+++ b/api-docs/api-reference/zones-operations.rst
@@ -10,7 +10,7 @@ collects data from. Examples of monitoring zones are "US West",
 from which data is collected.
 
 An *endpoint*, also known as a *collector*, collects data from the monitoring
-zone. The endpoint is mapped directly to an individual machine or a virtual
+zone. The endpoint is mapped directly to an individual computer or a virtual
 machine. A monitoring zone contains many endpoints, all of which will be within
 the IP address range listed in the response. The opposite is not true, however,
 as there may be unallocated IP addresses or unrelated machines within that IP

--- a/api-docs/common-gs/how-to-use-curl.rst
+++ b/api-docs/common-gs/how-to-use-curl.rst
@@ -41,7 +41,7 @@ about creating environment variables, see :ref:`Configure environment variables
 ..  note::
 
     The cURL request examples use a backslash (``\``) as a line-continuation
-    symbol, which allows the command to continue across multiple lines.
+    symbol, which indicates that the command continues across multiple lines.
 
 The cURL examples in this guide use the following command-line options.
 

--- a/api-docs/general-api-info/limits.rst
+++ b/api-docs/general-api-info/limits.rst
@@ -74,7 +74,7 @@ in the :ref:`API Reference <api-reference>`.
 Resource limits
 ~~~~~~~~~~~~~~~
 
-The following table below lists the default limits for different resources.
+The following table lists the default limits for different resources.
 When you exceed the threshold for checks or alarms, API requests to create
 a check or alarm return the
 following error:  ``400 Limit has been reached``.

--- a/api-docs/getting-started/concepts.rst
+++ b/api-docs/getting-started/concepts.rst
@@ -131,7 +131,7 @@ datacenter, however in the monitoring system, you can think of it more as a
 geographical region.
 
 You can launch checks for a particular entity from multiple monitoring zones.
-This allows you to observe the performance of an entity from different regions
+This enables you to observe the performance of an entity from different regions
 of the world. It is also a way to prevent noisy alarms. For example, if the
 check from one monitoring zone reports that an entity is down, a second or
 third monitoring zone might report that the entity is up and running. This

--- a/api-docs/getting-started/install-configure.rst
+++ b/api-docs/getting-started/install-configure.rst
@@ -263,7 +263,7 @@ Red Hat
 #. Create and edit a text file at
    /etc/yum.repos.d/rackspace-cloud-monitoring.repo with your favorite
    text editor (like nano or vi). Find your Linux distribution and
-   version in the table below, then add the listed configuration block
+   version in the following table, then add the listed configuration block
    to the ``rackspace-cloud-monitoring.repo`` file to add the agent
    repository to yum (Please add the WHOLE BLOCK):
 
@@ -359,7 +359,7 @@ Fedora
 #. Create and edit a text file at
    /etc/yum.repos.d/rackspace-cloud-monitoring.repo with your favorite
    text editor (like nano or vi). Find your Linux distribution and
-   version in the table below, then add the listed configuration block
+   version in the following table, then add the listed configuration block
    to the rackspace-cloud-monitoring.repo file to add the agent
    repository to yum (Please add the WHOLE BLOCK).
 
@@ -461,7 +461,7 @@ CentOS
 #. Create and edit a text file at
    /etc/yum.repos.d/rackspace-cloud-monitoring.repo with your favorite
    text editor (like nano or vi). Find your Linux distribution and
-   version in the table below, then add the listed configuration block
+   version in the following table, then add the listed configuration block
    to the rackspace-cloud-monitoring.repo file to add the agent
    repository to yum (Please add the WHOLE BLOCK).
 
@@ -1321,7 +1321,7 @@ Delete a server-side configuration file and its checks and alarms
 If a server-side YAML configuration file is removed from a server, the
 agent deletes the check and corresponding alarms configured in the file
 when the server next reads the file. The YAML files are read every time
-you start the agent. For information on starting the agent, see
+you start the agent. For information about starting the agent, see
 :ref:`Start the agent <start-the-agent>`.
 
 .. _troubleshoot-agent-configuration-with-YAML:

--- a/api-docs/index.rst
+++ b/api-docs/index.rst
@@ -25,7 +25,7 @@ you receive from using the Rackspace Monitoring API include the following:
 
 - **Monitoring from Multiple Datacenters**
 
-  Rackspace Monitoring allows you to simultaneously monitor the performance of
+  Rackspace Monitoring enables you to simultaneously monitor the performance of
   different resources from multiple datacenters and provides a clear picture
   of overall system health. It includes tunable parameters to interpret mixed
   results which help you to create deliberate and accurate alerting policies.
@@ -44,7 +44,7 @@ you receive from using the Rackspace Monitoring API include the following:
 
 - **Collection of Data**
 
-  Rackspace Monitoring allows you to collect a variety of data
+  Rackspace Monitoring enables you to collect a variety of data
   that you can use for other tasks, such as researching trends or
   measuring critical data. For more information, see
   :ref:`Metrics <metrics-operations>`.

--- a/api-docs/release-notes/releases/cmv1.18.rst
+++ b/api-docs/release-notes/releases/cmv1.18.rst
@@ -14,7 +14,7 @@ Resolved issues
 
 The following agent-specific changes were made:
 
-- On Windows, made a change to properly close stdin when gathering the machine
+- On Windows, made a change to properly close stdin when gathering the computer
   ID.
 
 - Made various hostinfo improvements.

--- a/api-docs/release-notes/releases/cmv1.20.rst
+++ b/api-docs/release-notes/releases/cmv1.20.rst
@@ -28,7 +28,7 @@ The following agent-specific changes were made:
 * Fixed an issue in an underlying library performing resolv.conf parsing. If
   there was more than one whitespace character in-between the ``nameserver``
   and ``ip`` then the application would not discover the DNS servers
-  correctly. This release allows for these extra characters.
+  correctly. This release supports the use of these extra characters.
 
 
 Known issues

--- a/api-docs/release-notes/releases/cmv1.3.rst
+++ b/api-docs/release-notes/releases/cmv1.3.rst
@@ -48,7 +48,7 @@ Resolved issues
 
 - Fixed writable date and time fields that were supposed to be immutable.
 
-- Fixed the DSL string escaping to allow you to specify special characters.
+- Fixed the DSL string escaping to enable you to specify special characters.
   See the following example:
 
    .. code::

--- a/api-docs/release-notes/releases/cmv1.6.rst
+++ b/api-docs/release-notes/releases/cmv1.6.rst
@@ -8,7 +8,7 @@ What's new
 ----------
 
 - The new `PagerDuty notification type <https://developer.rackspace.com/docs/cloud-monitoring/v1/developer-guide/#pagerduty-notification-type>`__
-  is now fully documented. This notification type allows you to use PagerDuty
+  is now fully documented. This notification type enables you to use PagerDuty
   to receive notifications via a page. For details, see
   `Rackspace Monitoring Adds PagerDuty Integration <http://developer.rackspace.com/blog/cloud-monitoring-adds-pagerduty-integration.html>`__
   blog post.

--- a/api-docs/release-notes/releases/cmv1.7.rst
+++ b/api-docs/release-notes/releases/cmv1.7.rst
@@ -10,7 +10,7 @@ What's new
 Server-side configuration is now available. For details, see
 `Install and configure the agent </cm/api/v1.0/cm-getting-started/content/install-configure.html#agent-config-file>`__.
 
-Server-side configuration allows checks and alarms to be configured using a
+Server-side configuration enables you to configure checks and alarms by using a
 YAML file. Users must update their monitoring agent to take advantage of this
 new feature.
 

--- a/api-docs/release-notes/releases/cmv1.8.rst
+++ b/api-docs/release-notes/releases/cmv1.8.rst
@@ -7,7 +7,7 @@ What's new
 ----------
 
 - An `SMS notification type <https://developer.rackspace.com/docs/cloud-monitoring/v1/developer-guide/#sms-notification-type>`__
-  is now available. This notification type allows Rackspace Monitoring users
+  is now available. This notification type enables Rackspace Monitoring users
   to receive notifications on an SMS-enabled mobile phone.
 
 This API-only feature is available globally without regard to region.

--- a/api-docs/tech-ref-info/alert-triggers-and-alarms.rst
+++ b/api-docs/tech-ref-info/alert-triggers-and-alarms.rst
@@ -375,7 +375,7 @@ policies and their trade-offs are described next.
 	zones report resource CRITICAL and the previous alert state was OK.
 
 	The ``ALL`` policy is the most accurate, but is also prone to failure in
-	significant failure scenarios. If a network partition hapens between our
+	significant failure scenarios. If a network partition happens between our
 	internal data centers, the alert might be delayed due to the
 	election process. In this case, a computer has to be marked down,
 	then the checks are re-evaluated as a group. If they come to a
@@ -439,7 +439,7 @@ like the one shown in the following example.
 
    	Notice the order of the following two statements.  Because the function runs
    	sequentially, you must specify the most specific match condition first.
-   	This is true for all conditions, it is commonly exposed in statements like this.
+   	This is true for all conditions and is commonly exposed in statements like this.
 
 .. code::
 

--- a/api-docs/tech-ref-info/alert-triggers-and-alarms.rst
+++ b/api-docs/tech-ref-info/alert-triggers-and-alarms.rst
@@ -52,8 +52,8 @@ the alerting system works:
       If a check fails to execute, by default alarm associated with
       check returns a ``CRITICAL`` state.
 
-      This may change in future versions of the product, however this
-      is currently the only behavior allowed. This represents a
+      This might change in future versions of the product, however this
+      is currently the only behavior supported. This represents a
       subclass of failures similar to *Connection Timeout* or other
       errors where the result wasn't simply a failure result, but a
       result where the user was unable to run the check at all.
@@ -375,9 +375,9 @@ policies and their trade-offs are described next.
 	zones report resource CRITICAL and the previous alert state was OK.
 
 	The ``ALL`` policy is the most accurate, but is also prone to failure in
-	significant failure scenarios. If a network partition between our
-	internal data centers happens, the alert could be delayed due to the
-	election process. In this case, a machine has to be marked down,
+	significant failure scenarios. If a network partition hapens between our
+	internal data centers, the alert might be delayed due to the
+	election process. In this case, a computer has to be marked down,
 	then the checks are re-evaluated as a group. If they come to a
 	consensus (with the downed collector) then an alert is generated.
 
@@ -433,14 +433,13 @@ such as bytes_in on an network interface, this will give you the
 **Percent function**
 
 The **percent** function is used to calculate a percentage, useful in situations
-like the example below.
+like the one shown in the following example.
 
 .. note::
 
-   	Notice the order of the two statements below, since it executes
-   	sequentially it is important to be most specific as the first matched
-   	condition wins. This is true for all conditions, it is commonly
-   	exposed in statements like this.
+   	Notice the order of the following two statements.  Because the function runs
+   	sequentially, you must specify the most specific match condition first.
+   	This is true for all conditions, it is commonly exposed in statements like this.
 
 .. code::
 
@@ -586,7 +585,7 @@ SSH checks
 ----------
 
 The following example uses the Rackspace Monitoring command
-line interface (CLI). For information on downloading and installing the
+line interface (CLI). For information about downloading and installing the
 CLI, see `Rackspace Monitoring CLI <https://github.com/racker/rackspace-monitoring-cli>`_.
 
 One of the most widely used remote checks is the SSH check. This check not

--- a/api-docs/tech-ref-info/check-types/agent-check-type-ref.rst
+++ b/api-docs/tech-ref-info/check-types/agent-check-type-ref.rst
@@ -752,7 +752,7 @@ The following descriptions provide information about parameter values.
    * - Parameter
      - Description
    * - name
-     - The name of the metric. No spaces are allowed. The format is
+     - The name of the metric. Spaces are not supported. The format is
        alpha numeric with colon (:), underscore (\_) and dot (.) allowed.
        Example: ``memory_free``.
    * - type

--- a/api-docs/tech-ref-info/check-types/check-return-codes.rst
+++ b/api-docs/tech-ref-info/check-types/check-return-codes.rst
@@ -19,7 +19,7 @@ provides a resolution for the issue.
    * - ``prevented by ACL 'global'``
      - The HTTP remote check is attempting to access an IP Address that is a
        private address (127.x.x.x, 192.168.x.x, etc).
-     - Private IP addresses are not allowed. Specify a public IP address
+     - Private IP addresses are not supported. Specify a public IP address
        instead.
    * - unknown content encoding
      - The content could not be copied fully to the monitoring zone endpoint.

--- a/api-docs/tech-ref-info/check-types/host-info-check-type-ref.rst
+++ b/api-docs/tech-ref-info/check-types/host-info-check-type-ref.rst
@@ -10,7 +10,7 @@ Hostinfo checks
 
 Hostinfo checks are a special class of checks that run on demand.
 
-In contrast to the remote and agent check types which allow you to schedule
+In contrast to the remote and agent check types which enable you to schedule
 alarms or alerts for remote and agent-type checks and run them on a regular
 schedule, you cannot schedule Hostinfo checks or create alarms or alerts for
 them.
@@ -180,7 +180,7 @@ service.
           https://monitoring.api.rackspacecloud.com/v1.0/ \
           <tenandID>/agents/<agent_id>/host_info/<hostinfo_type>
           
-For more information on how to work with checks using the Rackspace Monitoring API, see the
+For more information about how to work with checks using the Rackspace Monitoring API, see the
 Checks section in the Rackspace Monitoring Developer Guide. For more information working with Hostinfo checks,
 see the Agent host information.
 


### PR DESCRIPTION
Revised content that used the following terms incorrectly:
_allow_, _below_, _machine_, _information on_ per Rackspace style guide:
http://rackerlabs.github.io/docs-rackspace/style-guide/terminology-guidelines.html
Partially addresses issues found during [Quality Audit](https://github.com/rackerlabs/docs-cloud-monitoring/issues/8).

@cyrichardson Please review this PR when you have a chance. Thanks!
