### PR TITLE
added missing install command for Ubuntu 16.04

### DIFF
--- a/api-docs/getting-started/install-configure.rst
+++ b/api-docs/getting-started/install-configure.rst
@@ -152,6 +152,12 @@ Ubuntu
       .. code::
 
           sudo sh -c 'echo "deb http://stable.packages.cloudmonitoring.rackspace.com/ubuntu-15.04-x86_64 cloudmonitoring main" > /etc/apt/sources.list.d/rackspace-monitoring-agent.list'
+	  
+   -  **Ubuntu 16.04**:
+
+      .. code::
+
+          sudo sh -c 'echo "deb http://stable.packages.cloudmonitoring.rackspace.com/ubuntu-16.04-x86_64 cloudmonitoring main" > /etc/apt/sources.list.d/rackspace-monitoring-agent.list'
 
 #. Download the signing key for the agent repository and add it to APT:
 


### PR DESCRIPTION
We didn't have the installer command in the documentation for Ubuntu 16.04 I have added this to the document.

**Quality audit reminder**

Doc team: While logged in using your O365 account, complete the quality checklist at http://bit.ly/2hwvBKX. Use the checklist for significant doc changes or additions submitted by you or a non-doc staff contributor.
