### PR TITLE
Add new methods for private network monitoring zones

### DIFF
--- a/api-docs/api-reference/methods/delete-private-monitor-zone.rst
+++ b/api-docs/api-reference/methods/delete-private-monitor-zone.rst
@@ -1,0 +1,61 @@
+.. _delete-private-monitor-zone:
+
+Delete a private monitoring zone by ID
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code::
+
+    DELETE monitoring_zones/{monitoringZoneId}
+
+Deletes a specified private monitoring zone from your account. Also deletes
+any checks and alarms defined for that monitoring zone.
+
+The following table shows the possible response codes for this operation:
+
++--------------------------+-------------------------+-------------------------+
+|Response Code             |Name                     |Description              |
++==========================+=========================+=========================+
+|204                       |OK                       |The server has fulfilled |
+|                          |                         |the request. Does not    |
+|                          |                         |return a response body.  |
++--------------------------+-------------------------+-------------------------+
+|401                       |Unauthorized             |The system received a    |
+|                          |                         |request from a user that |
+|                          |                         |is not authenticated.    |
++--------------------------+-------------------------+-------------------------+
+|403                       |Forbidden                |The system received a    |
+|                          |                         |request that the user is |
+|                          |                         |not authorized to make.  |
++--------------------------+-------------------------+-------------------------+
+|404                       |Not Found                |The URL, entity, or      |
+|                          |                         |account requested is not |
+|                          |                         |found in the system.     |
++--------------------------+-------------------------+-------------------------+
+|500                       |Internal Server Error    |An unexpected condition  |
+|                          |                         |was encountered.         |
++--------------------------+-------------------------+-------------------------+
+|503                       |Service Unavailable      |The system is            |
+|                          |                         |experiencing heavy load  |
+|                          |                         |or another system        |
+|                          |                         |failure.                 |
++--------------------------+-------------------------+-------------------------+
+
+Request
+-------
+
+The following table shows the header parameters for the request:
+
++-----------------+----------------+-----------------------------------------------+
+|Name             |Type            |Description                                    |
++=================+================+===============================================+
+|X-Auth-Token     |String          |A valid authentication token with              |
+|                 |*(Required)*    |administrative access. For details, see        |
+|                 |                |:ref:`Get your credentials <get-credentials>`  |
++-----------------+----------------+-----------------------------------------------+
+
+.. note:: This operation does not accept a request body.
+
+Response
+--------
+
+This operation does not return a response body.

--- a/api-docs/api-reference/methods/post-create-a-notification-plan.rst
+++ b/api-docs/api-reference/methods/post-create-a-notification-plan.rst
@@ -54,7 +54,6 @@ The following table shows the header parameters for the request:
 |                 |                |:ref:`Get your credentials <get-credentials>`  |
 +-----------------+----------------+-----------------------------------------------+
 
-.. note:: This operation does not accept a request body.
 
 **Example Create notification plan: JSON request**
 

--- a/api-docs/api-reference/methods/post-create-an-agent-token.rst
+++ b/api-docs/api-reference/methods/post-create-an-agent-token.rst
@@ -55,8 +55,6 @@ The following table shows the header parameters for the request:
 +-----------------+----------------+-----------------------------------------------+
 
 
-.. note:: This operation does not accept a request body.
-
 
 **Example Create agent token: JSON request**
 

--- a/api-docs/api-reference/methods/post-create-private-monitor-zone.rst
+++ b/api-docs/api-reference/methods/post-create-private-monitor-zone.rst
@@ -1,0 +1,73 @@
+.. _create-private-monitor-zone:
+
+Create a private monitoring zone
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code::
+
+    POST /monitoring_zones/
+
+Create a new private monitoring zone.
+
+The following table shows the possible response codes for this operation:
+
++--------------------------+-------------------------+-------------------------+
+|Response Code             |Name                     |Description              |
++==========================+=========================+=========================+
+|201                       |OK                       |The 'Location' header    |
+|                          |                         |contains a link to the   |
+|                          |                         |newly created entity.    |
++--------------------------+-------------------------+-------------------------+
+|400                       |Bad request              |The system received an   |
+|                          |                         |invalid value in a       |
+|                          |                         |request.                 |
++--------------------------+-------------------------+-------------------------+
+|401                       |Unauthorized             |The system received a    |
+|                          |                         |request from a user that |
+|                          |                         |is not authenticated.    |
++--------------------------+-------------------------+-------------------------+
+|403                       |Forbidden                |The system received a    |
+|                          |                         |request that the user is |
+|                          |                         |not authorized to make.  |
++--------------------------+-------------------------+-------------------------+
+|500                       |Internal Server Error    |An unexpected condition  |
+|                          |                         |was encountered.         |
++--------------------------+-------------------------+-------------------------+
+|503                       |Service Unavailable      |The system is            |
+|                          |                         |experiencing heavy load  |
+|                          |                         |or another system        |
+|                          |                         |failure.                 |
++--------------------------+-------------------------+-------------------------+
+Request
+-------
+
+The following table shows the header parameters for the request:
+
++-----------------+----------------+-----------------------------------------------+
+|Name             |Type            |Description                                    |
++=================+================+===============================================+
+|X-Auth-Token     |String          |A valid authentication token with              |
+|                 |*(Required)*    |administrative access. For details, see        |
+|                 |                |:ref:`Get your credentials <get-credentials>`  |
++-----------------+----------------+-----------------------------------------------+
+
+.. note:: This operation does not accept a request body.
+
+**Example Create a private monitoring zone: JSON request**
+
+.. code::
+
+   {
+       <!--Todo: process Request example -->
+   }
+
+Response
+--------
+
+**Example Create a private monitoring zone: JSON response**
+
+.. code::
+
+   {
+       <!--Todo: process Response Object and its headers, schema, examples -->
+   }

--- a/api-docs/api-reference/methods/post-create-private-monitor-zone.rst
+++ b/api-docs/api-reference/methods/post-create-private-monitor-zone.rst
@@ -1,7 +1,7 @@
 .. _create-private-monitor-zone:
 
 Create a private monitoring zone
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code::
 

--- a/api-docs/api-reference/methods/post-create-private-monitor-zone.rst
+++ b/api-docs/api-reference/methods/post-create-private-monitor-zone.rst
@@ -51,23 +51,18 @@ The following table shows the header parameters for the request:
 |                 |                |:ref:`Get your credentials <get-credentials>`  |
 +-----------------+----------------+-----------------------------------------------+
 
-.. note:: This operation does not accept a request body.
 
 **Example Create a private monitoring zone: JSON request**
+
+The request body requires only a ``label`` field of type string.
 
 .. code::
 
    {
-       <!--Todo: process Request example -->
+       "label": "Zone A Information"
    }
 
 Response
 --------
 
-**Example Create a private monitoring zone: JSON response**
-
-.. code::
-
-   {
-       <!--Todo: process Response Object and its headers, schema, examples -->
-   }
+This operation does not return a response body.

--- a/api-docs/api-reference/methods/post-perform-a-traceroute.rst
+++ b/api-docs/api-reference/methods/post-perform-a-traceroute.rst
@@ -52,7 +52,6 @@ The following table shows the header parameters for the request:
 |                 |                |:ref:`Get your credentials <get-credentials>`  |
 +-----------------+----------------+-----------------------------------------------+
 
-.. note:: This operation does not accept a request body.
 
 **Example Traceroute: JSON request**
 

--- a/api-docs/api-reference/methods/put-update-private-monitor-zone.rst
+++ b/api-docs/api-reference/methods/put-update-private-monitor-zone.rst
@@ -7,7 +7,7 @@ Update a private monitor zone by ID
 
     PUT /monitoring_zones/{monitoringZoneId}
 
-Updates the private monitoring zone specified by ``monitoringZoneId``. You 
+Updates the private monitoring zone specified by ``monitoringZoneId``. You
 can make partial updates to a private monitoring zone. When you submit the
 update request, only specify the parameters that you want to update.
 
@@ -59,17 +59,15 @@ The following table shows the header parameters for the request:
 |                 |                |:ref:`Get your credentials <get-credentials>`  |
 +-----------------+----------------+-----------------------------------------------+
 
-.. note:: This operation does not accept a request body.
-
 **Example Update a private monitoring zone: JSON request**
 
 .. code::
 
    {
-       <!--Todo: process Request example -->
+       "label": "Zone A Updated Information"
    }
 
 Response
 --------
 
-The following operation does not return a response body.
+This operation does not return a response body.

--- a/api-docs/api-reference/methods/put-update-private-monitor-zone.rst
+++ b/api-docs/api-reference/methods/put-update-private-monitor-zone.rst
@@ -1,0 +1,75 @@
+.. _update-private-monitor-zone:
+
+Update a private monitor zone by ID
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code::
+
+    PUT /monitoring_zones/{monitoringZoneId}
+
+Updates the private monitoring zone specified by ``monitoringZoneId``. You 
+can make partial updates to a private monitoring zone. When you submit the
+update request, only specify the parameters that you want to update.
+
+The following table shows the possible response codes for this operation:
+
++--------------------------+-------------------------+-------------------------+
+|Response Code             |Name                     |Description              |
++==========================+=========================+=========================+
+|204                       |OK                       |The server has fulfilled |
+|                          |                         |the request but does not |
+|                          |                         |need to return an entity-|
+|                          |                         |body.                    |
++--------------------------+-------------------------+-------------------------+
+|400                       |Bad request              |The system received an   |
+|                          |                         |invalid value in a       |
+|                          |                         |request.                 |
++--------------------------+-------------------------+-------------------------+
+|401                       |Unauthorized             |The system received a    |
+|                          |                         |request from a user that |
+|                          |                         |is not authenticated.    |
++--------------------------+-------------------------+-------------------------+
+|403                       |Forbidden                |The system received a    |
+|                          |                         |request that the user is |
+|                          |                         |not authorized to make.  |
++--------------------------+-------------------------+-------------------------+
+|404                       |Not Found                |The URL, entity, or      |
+|                          |                         |account requested is not |
+|                          |                         |found in the system.     |
++--------------------------+-------------------------+-------------------------+
+|500                       |Internal Server Error    |An unexpected condition  |
+|                          |                         |was encountered.         |
++--------------------------+-------------------------+-------------------------+
+|503                       |Service Unavailable      |The system is            |
+|                          |                         |experiencing heavy load  |
+|                          |                         |or another system        |
+|                          |                         |failure.                 |
++--------------------------+-------------------------+-------------------------+
+
+Request
+-------
+
+The following table shows the header parameters for the request:
+
++-----------------+----------------+-----------------------------------------------+
+|Name             |Type            |Description                                    |
++=================+================+===============================================+
+|X-Auth-Token     |String          |A valid authentication token with              |
+|                 |*(Required)*    |administrative access. For details, see        |
+|                 |                |:ref:`Get your credentials <get-credentials>`  |
++-----------------+----------------+-----------------------------------------------+
+
+.. note:: This operation does not accept a request body.
+
+**Example Update a private monitoring zone: JSON request**
+
+.. code::
+
+   {
+       <!--Todo: process Request example -->
+   }
+
+Response
+--------
+
+The following operation does not return a response body.

--- a/api-docs/api-reference/zones-operations.rst
+++ b/api-docs/api-reference/zones-operations.rst
@@ -35,12 +35,20 @@ A check references a list of monitoring zones it should be run from.
 Use the following monitoring zones API operations to get information about
 monitoring zones and to run traceroutes.
 
+For Private Network Monitoring, API operations are included to create, update,
+and delete private monitoring zones.
+
 .. contents::
    :local:
    :depth: 1
 
-.. note:: Users cannot create, update, or delete monitoring zones.
+.. note::
+
+   Users cannot create, update, or delete monitoring zones, unless the monitoring zone is Private Network Monitoring.
 
 .. include:: methods/get-list-monitoring-zones.rst
 .. include:: methods/get-monitoring-zone-by-id.rst
 .. include:: methods/post-perform-a-traceroute.rst
+.. include:: methods/post-create-private-monitor-zone.rst
+.. include:: methods/put-update-private-monitor-zone.rst
+.. include:: methods/delete-private-monitor-zone.rst


### PR DESCRIPTION
Fix issue #52 

Draft from information available at this time. Used existing  POST, PUT, and DELETE API operations to model the 3 new methods.

Still need example requests and responses.