### PR TITLE
Added Information for Debian Stretch

### DIFF
--- a/api-docs/getting-started/install-configure.rst
+++ b/api-docs/getting-started/install-configure.rst
@@ -159,6 +159,12 @@ Debian
    listed, without line breaks, to add the monitoring agent package
    repository to APT.
 
+   -  **Debian Stretch**:
+
+      .. code::
+
+          sudo sh -c 'echo "deb http://stable.packages.cloudmonitoring.rackspace.com/debian-stretch-x86_64 cloudmonitoring main" > /etc/apt/sources.list.d/rackspace-monitoring-agent.list'
+
    -  **Debian Squeeze**:
 
       .. code::

--- a/api-docs/getting-started/install-configure.rst
+++ b/api-docs/getting-started/install-configure.rst
@@ -1446,3 +1446,4 @@ some agent checks.
 
 .. _entity: http://docs.rackspace.com/cm/api/v1.0/cm-devguide/content/service-entities.html
 .. _checks: http://docs.rackspace.com/cm/api/v1.0/cm-devguide/content/service-checks.html
+


### PR DESCRIPTION
Cloud Monitoring agent section lacked Stretch instructions. It would easily extrapolated from the other documentation, but it is nice to have it specified.



   -  **Debian Stretch**:

      .. code::

          sudo sh -c 'echo "deb http://stable.packages.cloudmonitoring.rackspace.com/debian-stretch-x86_64 cloudmonitoring main" > /etc/apt/sources.list.d/rackspace-monitoring-agent.list'